### PR TITLE
Set XDG variables if they are not set

### DIFF
--- a/bash/bashrc.d/xdg-specs.bash
+++ b/bash/bashrc.d/xdg-specs.bash
@@ -1,0 +1,20 @@
+
+if [ -z "$XDG_CONFIG_HOME" ]; then
+    export XDG_CONFIG_HOME=$HOME/.config
+fi
+
+if [ -z "$XDG_CACHE_HOME" ]; then
+    export XDG_CACHE_HOME=$HOME/.cache
+fi
+
+if [ -z "$XDG_DATA_HOME" ]; then
+    export XDG_DATA_HOME=$HOME/.local/share
+fi
+
+if [ -z "$XDG_DATA_DIRS" ]; then
+    export XDG_DATA_DIRS=/usr/local/share:/usr/share
+fi
+
+if [ -z "$XDG_CONFIG_DIRS" ]; then
+    export XDG_CONFIG_DIRS=/etc/xdg
+fi


### PR DESCRIPTION
A growing number of applications support freedesktop XDG Base Directory
Specification[1].  This patch sets the XDG variables in accordance to
Arch linux's wiki information [2].

[1] XDG Base Directory Specification.  https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

[2] XDG Base Directory support.  https://wiki.archlinux.org/index.php/XDG_Base_Directory_support